### PR TITLE
2e2 bug fix

### DIFF
--- a/e2e-tests/blog_app.spec.js
+++ b/e2e-tests/blog_app.spec.js
@@ -74,7 +74,159 @@ describe('Blog app', () => {
       await expect(page.getByRole('button', { name: 'cancel' })).toBeVisible()
     })
 
+    test('new blog can be created', async ({ page }) => {
+      const newBlog = {
+        title: 'example Blog',
+        author: 'example Author',
+        url: 'test.com/exampleBlog'
+      }
+      
+      await createBlog(page, newBlog)
 
-    
+      const blogOnPage = await page.locator('.DetailsHidden')
+
+      await expect(blogOnPage).toContainText(newBlog.title)
+      await expect(blogOnPage).toBeVisible
+    })
+
+    test('blog can be liked', async ({ page }) => {
+      const newBlog = {
+        title: 'example Blog',
+        author: 'example Author',
+        url: 'test.com/exampleBlog'
+      }
+      
+      await createBlog(page, newBlog)
+
+      await page.getByRole('button', { name: 'view' }).click()
+      const likesText = page.locator('.DetailsShown >> text=Likes:')
+      await expect(likesText).toContainText('Likes: 0')
+      
+      await page.getByRole('button', { name: 'like' }).click()
+      await expect(likesText).toContainText('Likes: 1')  
+    })
+
+    test('remove button can be seen by user who created the blog', async ({ page }) => {
+      const newBlog = {
+        title: 'example Blog',
+        author: 'example Author',
+        url: 'test.com/exampleBlog'
+      }
+      
+      await createBlog(page, newBlog)
+
+      await page.getByRole('button', { name: 'view' }).click()
+
+      await expect(page.getByRole('button', { name: 'remove' })).toBeVisible()
+    })
+
+    test('a blog can be deleted by the user that created the blog', async ({ page }) => {
+      const newBlog = {
+        title: 'example Blog',
+        author: 'example Author',
+        url: 'test.com/exampleBlog'
+      }
+      
+      await createBlog(page, newBlog)
+
+      await page.getByRole('button', { name: 'view' }).click()
+
+      page.on('dialog', async (dialog) => {
+        console.log(`Dialog message: ${dialog.message()}`)
+        await dialog.accept()
+      })
+
+      await page.getByRole('button', { name: 'remove' }).click()
+
+      await expect(page.getByText('Removed blog successfully')).toBeVisible()
+
+      await expect(page.getByText(newBlog.title)).toHaveCount(0)
+    })
+
+    test('remove button is not visible to user who is not creator', async ({ page, request }) => {
+      await request.post('http://localhost:3003/api/users', {
+        data: {
+          name: 'Test User2',
+          username: 'testuser2',
+          password: 'password123'
+        }
+      })
+      
+      const newBlog = {
+        title: 'example Blog',
+        author: 'example Author',
+        url: 'test.com/exampleBlog'
+      }
+      
+      await createBlog(page, newBlog)
+
+      await expect(page.getByText(`a new blog ${newBlog.title} by ${newBlog.author} added`)).toBeVisible()
+
+      await page.getByRole('button', { name: 'logout' }).click()
+
+      await page.getByTestId('username').fill('testuser2')
+      await page.getByTestId('password').fill('password123')
+      await page.getByRole('button', { name: 'login' }).click()
+
+      await expect(page.getByText('Test User2 logged in')).toBeVisible()
+
+      await page.getByRole('button', { name: 'view' }).click()
+      await expect(page.getByRole('button', { name: 'remove' })).not.toBeVisible()      
+    })
+
+    describe('when there are multiple blogs', () => {
+      beforeEach( async ({ page }) => {
+        const blogs = [
+          { title: 'example Blog1', author: 'example Author', url: 'test.com/exampleBlog', likes: 3 },
+          { title: 'example Blog2', author: 'example Author', url: 'test.com/exampleBlog', likes: 2 },
+          { title: 'example Blog3', author: 'example Author', url: 'test.com/exampleBlog', likes: 1 }
+        ]
+
+        for (const blog of blogs) {
+          await createBlog(page, blog)
+          await page.getByText(blog.title).getByRole('button', { name: 'view' }).click()
+          await page.getByRole('button', { name: 'cancel' }).click()
+        }
+
+        const blogsOnPage = await page.locator('[data-testid="blog-item"]')
+
+        for (let i = 0; i < blogs.length; i++) {
+            const blog = blogsOnPage.nth(i)
+            const blogTitle = await blog.textContent()
+            console.log(blogTitle)
+
+            const blogData = blogs.find(blog => blogTitle?.includes(blog.title))
+
+            if (blogData) {
+              //This loop does not always hit the like button the desired number of times. Probably a timing issue
+              for (let j = 0; j < blogData.likes; j++) {
+                await blog.getByRole('button', { name: 'like' }).click()
+              }
+            }
+        }
+        await page.waitForTimeout(500)
+      })
+      
+      test('number of blogs displayed equals number created', async ({ page }) => {
+        const blogsOnPage = page.locator('[data-testid="blog-item"]')
+        await expect(blogsOnPage).toHaveCount(3)
+      })
+      
+      test('blogs are displayed in decending order', async ({ page }) => {
+        const blogsOnPage = await page.locator('[data-testid="blog-item"]')
+        const likesOnPage = []
+
+        for (let i =0; i < 3; i++) {
+          const blog = blogsOnPage.nth(i)
+          const likeText = await blog.textContent()
+          const match = likeText?.match(/Likes:\s*(\d+)/i)
+          const likes = match  ? parseInt(match[1], 10) : 0
+          likesOnPage.push(likes)
+        }
+
+        const sorted = [...likesOnPage].sort((a, b) => b - a)
+        expect(likesOnPage).toEqual(sorted)        
+      })
+    })
   }) 
 })

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -14,7 +14,7 @@ import { defineConfig, devices } from '@playwright/test';
  */
 export default defineConfig({
   webServer: {
-    command: 'npm run dev:server',
+    command: 'npm run start:test',
     url: 'http://localhost:3003/health',
     timeout: 120 * 1000,
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
Fixed bug where some playwright tests were failing, despite running in original app. Updated playwright config to start a test server, so that when tests run, added test blogs and users go to a test DB instead of prod DB, which was causing the bug, since the test doesn't account for duplicate entries in DB. All tests passed locally.